### PR TITLE
[CUS-498] - dumpIcgJson function

### DIFF
--- a/src/Silisizer.cpp
+++ b/src/Silisizer.cpp
@@ -318,7 +318,9 @@ void dumpIcgJson(const char *path) {
   std::unique_ptr<sta::LeafInstanceIterator> it(network->leafInstanceIterator());
   while (it->hasNext()) {
     sta::Instance *inst = it->next();
-    sta::LibertyCell *lc = network->libertyCell(network->cell(inst));
+    sta::Cell *cell = network->cell(inst);
+    if (!cell) continue;
+    sta::LibertyCell *lc = network->libertyCell(cell);
     if (!lc || !lc->isClockGate()) continue;
     if (!first) f << ",";
     f << "\n    \"" << jsonName(network->pathName(inst))

--- a/src/Silisizer.cpp
+++ b/src/Silisizer.cpp
@@ -285,13 +285,10 @@ int Silisizer::silisize(const char *workdir) {
   return 0;
 }
 
-static std::string jsonEscape(std::string_view s) {
+// Remove escape characters from JSON output
+static std::string jsonName(const char *s) {
   std::string out;
-  out.reserve(s.size());
-  for (char c : s) {
-    if (c == '"' || c == '\\') out.push_back('\\');
-    out.push_back(c);
-  }
+  for (; *s; ++s) if (*s != '\\') out.push_back(*s);
   return out;
 }
 
@@ -311,7 +308,7 @@ void dumpIcgJson(const char *path) {
   bool first = true;
   for (const sta::Instance *reg : sta->clockGatedRegisters()) {
     if (!first) f << ",";
-    f << "\n    \"" << jsonEscape(network->pathName(reg)) << "\"";
+    f << "\n    \"" << jsonName(network->pathName(reg)) << "\"";
     first = false;
   }
   f << (first ? "" : "\n  ") << "],\n  \"icgs\": {";
@@ -324,8 +321,8 @@ void dumpIcgJson(const char *path) {
     sta::LibertyCell *lc = network->libertyCell(network->cell(inst));
     if (!lc || !lc->isClockGate()) continue;
     if (!first) f << ",";
-    f << "\n    \"" << jsonEscape(network->pathName(inst))
-      << "\": \"" << jsonEscape(lc->name()) << "\"";
+    f << "\n    \"" << jsonName(network->pathName(inst))
+      << "\": \"" << jsonName(lc->name()) << "\"";
     first = false;
   }
   f << (first ? "" : "\n  ") << "}\n}\n";

--- a/src/Silisizer.cpp
+++ b/src/Silisizer.cpp
@@ -285,8 +285,6 @@ int Silisizer::silisize(const char *workdir) {
   return 0;
 }
 
-// Minimal JSON string escape (only " and \). OpenSTA path/cell names do not
-// contain control characters that would otherwise need encoding.
 static std::string jsonEscape(std::string_view s) {
   std::string out;
   out.reserve(s.size());
@@ -297,6 +295,7 @@ static std::string jsonEscape(std::string_view s) {
   return out;
 }
 
+// JSON dumper for clock gating related instances
 void dumpIcgJson(const char *path) {
   sta::Sta *sta = sta::Sta::sta();
   sta::Network *network = sta->network();

--- a/src/Silisizer.cpp
+++ b/src/Silisizer.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <iostream>
 #include <list>
+#include <memory>
 
 #include "sta/Liberty.hh"
 #include "sta/Network.hh"
@@ -282,6 +283,53 @@ int Silisizer::silisize(const char *workdir) {
   // Clean up
   transforms.close();
   return 0;
+}
+
+// Minimal JSON string escape (only " and \). OpenSTA path/cell names do not
+// contain control characters that would otherwise need encoding.
+static std::string jsonEscape(std::string_view s) {
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s) {
+    if (c == '"' || c == '\\') out.push_back('\\');
+    out.push_back(c);
+  }
+  return out;
+}
+
+void dumpIcgJson(const char *path) {
+  sta::Sta *sta = sta::Sta::sta();
+  sta::Network *network = sta->network();
+
+  std::ofstream f(path);
+  if (!f.good()) {
+    std::cerr << "dump_icg_json: cannot open " << path << " for write" << std::endl;
+    return;
+  }
+
+  // Dump gated registers.
+  f << "{\n  \"gated_flops\": [";
+  bool first = true;
+  for (const sta::Instance *reg : sta->clockGatedRegisters()) {
+    if (!first) f << ",";
+    f << "\n    \"" << jsonEscape(network->pathName(reg)) << "\"";
+    first = false;
+  }
+  f << (first ? "" : "\n  ") << "],\n  \"icgs\": {";
+
+  // Dump clock-gating instances mapped to their liberty cell names.
+  first = true;
+  std::unique_ptr<sta::LeafInstanceIterator> it(network->leafInstanceIterator());
+  while (it->hasNext()) {
+    sta::Instance *inst = it->next();
+    sta::LibertyCell *lc = network->libertyCell(network->cell(inst));
+    if (!lc || !lc->isClockGate()) continue;
+    if (!first) f << ",";
+    f << "\n    \"" << jsonEscape(network->pathName(inst))
+      << "\": \"" << jsonEscape(lc->name()) << "\"";
+    first = false;
+  }
+  f << (first ? "" : "\n  ") << "}\n}\n";
 }
 
 }  // namespace silisizer

--- a/src/Silisizer.h
+++ b/src/Silisizer.h
@@ -24,4 +24,6 @@ class Silisizer : public sta::Sta {
   int silisize(const char *workdir);
 };
 
+void dumpIcgJson(const char *path);
+
 }  // namespace silisizer

--- a/src/Silisizer.i
+++ b/src/Silisizer.i
@@ -19,6 +19,7 @@
 %inline %{
 
 extern int silisize(const char *workdir);
+extern void dump_icg_json(const char *path);
 
 extern void test_abrt();
 extern void test_segv();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,6 +97,10 @@ int silisize(const char *workdir) {
   return sizer->silisize(workdir);
 }
 
+void dump_icg_json(const char *path) {
+  silisizer::dumpIcgJson(path);
+}
+
 void segv_call_fn() {
   int a;
   a = 6;


### PR DESCRIPTION
Dumps an ICG json in specified path to store all relevant information about ICGs.

Stores flip-flops connected to an ICG and ICG instances (mapped to their liberty names)