### PR TITLE
Add configurable timing convergence policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # Silisizer
 Operator resize for meeting timing.
+
+Run the timing optimizer from Tcl after loading and linking the design:
+
+```tcl
+sta::silisize workdir
+```
+
+Pass `-all` to upsize every eligible offender found during each timing pass
+instead of using adaptive batch sizing:
+
+```tcl
+sta::silisize -all workdir
+```
+
+Pass `-wns` to stop after three consecutive timing passes without WNS
+improvement, even if other violating paths could still improve:
+
+```tcl
+sta::silisize -wns workdir
+```
+
+The policies can be combined:
+
+```tcl
+sta::silisize -all -wns workdir
+```

--- a/src/Silisizer.cpp
+++ b/src/Silisizer.cpp
@@ -33,6 +33,9 @@ namespace silisizer {
 // DEBUG flag
 const bool DEBUG = 0;
 
+// Number of consecutive non-improving timing passes allowed by the WNS policy.
+const int WNS_STALL_ROUND_LIMIT = 3;
+
 // Replace all occurrences of `from` in `str` with `to`
 std::string replaceAll(std::string_view str, std::string_view from,
                        std::string_view to) {
@@ -55,7 +58,9 @@ std::string reverseOpenSTANaming(std::string cellname) {
 }
 
 // Silisizer: resize operator-level cells to resolve timing violations
-int Silisizer::silisize(const char *workdir) {
+int Silisizer::silisize(const char *workdir,
+                        bool upsize_all,
+                        bool stop_on_wns_stall) {
   // Initialize network
   sta::Network* network = this->network();
 
@@ -70,6 +75,7 @@ int Silisizer::silisize(const char *workdir) {
 
   // Iterate until the maximum number of iterations is reached
   double previous_wns = 1;
+  int wns_stall_rounds = 0;
   for (int cur_iter = 0; true; cur_iter++) {
     // Run timer to get violating paths (one per endpoint)
     std::cout << "Running timer..." << std::endl;
@@ -185,7 +191,26 @@ int Silisizer::silisize(const char *workdir) {
       break;
     }
 
-    // Sort top offender list and allow max list size of swaps_per_iter
+    // The WNS policy intentionally stops even while other violating paths may
+    // still benefit from resizing.
+    if (stop_on_wns_stall && cur_iter > 0) {
+      double delta_wns = wns - previous_wns;
+      if (delta_wns <= 0.0)
+        wns_stall_rounds++;
+      else
+        wns_stall_rounds = 0;
+
+      if (wns_stall_rounds >= WNS_STALL_ROUND_LIMIT) {
+        std::cout << "WNS did not improve for " << wns_stall_rounds
+                  << " consecutive rounds." << std::endl
+                  << "Final WNS: " << -(wns * 1e12) << std::endl
+                  << "WNS optimization done!" << std::endl;
+        break;
+      }
+    }
+
+    // Sort the offender list and, unless requested otherwise, limit it to the
+    // adaptive number of swaps for this iteration.
     std::list<std::pair<sta::Instance*, double>> offenders;
     for (const auto& pair : offending_inst_score)
       offenders.push_back(pair);
@@ -193,7 +218,8 @@ int Silisizer::silisize(const char *workdir) {
                       const std::pair<sta::Instance*, double>& b) {
       return a.second > b.second;
     });
-    offenders.resize(std::min(swaps_per_iter, (int) offenders.size()));
+    if (!upsize_all)
+      offenders.resize(std::min(swaps_per_iter, (int) offenders.size()));
 
     // DEBUG: Print the number of offenders
     if (DEBUG) std::cout << "offenders: " << offenders.size() << std::endl;
@@ -257,8 +283,8 @@ int Silisizer::silisize(const char *workdir) {
       std::cout << "Delta WNS frac: " << delta_wns_frac << std::endl;
     }
 
-    // Set effort based on delta WNS
-    if (delta_wns_frac < 0.1 && swaps_per_iter < 1048576)
+    // Set effort based on delta WNS when adaptive batching is enabled.
+    if (!upsize_all && delta_wns_frac < 0.1 && swaps_per_iter < 1048576)
       swaps_per_iter *= 2;
 
     // Print the current iteration and WNS

--- a/src/Silisizer.cpp
+++ b/src/Silisizer.cpp
@@ -110,7 +110,7 @@ int Silisizer::silisize(const char *workdir,
 
     // Initialize variables
     std::unordered_map<sta::Instance*, double> offending_inst_score;
-    double wns = 0.0f;
+    double wns = 0.0;
 
     // For each path with negative slack
     for (sta::PathEnd* pathend : ends) {

--- a/src/Silisizer.h
+++ b/src/Silisizer.h
@@ -21,7 +21,9 @@ namespace silisizer {
 class Silisizer : public sta::Sta {
  public:
   ~Silisizer() {}
-  int silisize(const char *workdir);
+  int silisize(const char *workdir,
+               bool upsize_all = false,
+               bool stop_on_wns_stall = false);
 };
 
 void dumpIcgJson(const char *path);

--- a/src/Silisizer.i
+++ b/src/Silisizer.i
@@ -18,7 +18,6 @@
 
 %inline %{
 
-extern int silisize(const char *workdir);
 extern void dump_icg_json(const char *path);
 
 extern void test_abrt();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,13 +98,14 @@ static int silisizer_argc;
 static char **silisizer_argv;
 static Silisizer *sizer = nullptr;
 
+// Tcl command wrapper for sta::silisize. It parses convergence policy flags
+// and borrows the workdir string from objv for the duration of this call.
 static int silisizeTclCmd(ClientData,
                           Tcl_Interp *interp,
                           int objc,
                           Tcl_Obj *const objv[]) {
   bool upsize_all = false;
   bool stop_on_wns_stall = false;
-  bool invalid_args = false;
   const char *workdir = nullptr;
 
   for (int i = 1; i < objc; i++) {
@@ -113,15 +114,20 @@ static int silisizeTclCmd(ClientData,
       upsize_all = true;
     else if (arg == "-wns")
       stop_on_wns_stall = true;
-    else if (!arg.empty() && arg[0] == '-')
-      invalid_args = true;
-    else if (!workdir)
+    else if (!arg.empty() && arg[0] == '-') {
+      std::string message =
+          "unknown option \"" + arg + "\": must be -all or -wns";
+      Tcl_SetObjResult(interp, Tcl_NewStringObj(message.c_str(), -1));
+      return TCL_ERROR;
+    } else if (!workdir)
       workdir = Tcl_GetString(objv[i]);
-    else
-      invalid_args = true;
+    else {
+      Tcl_WrongNumArgs(interp, 1, objv, "?-all? ?-wns? workdir");
+      return TCL_ERROR;
+    }
   }
 
-  if (!workdir || invalid_args) {
+  if (!workdir) {
     Tcl_WrongNumArgs(interp, 1, objv, "?-all? ?-wns? workdir");
     return TCL_ERROR;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,8 +98,38 @@ static int silisizer_argc;
 static char **silisizer_argv;
 static Silisizer *sizer = nullptr;
 
-int silisize(const char *workdir) {
-  return sizer->silisize(workdir);
+static int silisizeTclCmd(ClientData,
+                          Tcl_Interp *interp,
+                          int objc,
+                          Tcl_Obj *const objv[]) {
+  bool upsize_all = false;
+  bool stop_on_wns_stall = false;
+  bool invalid_args = false;
+  const char *workdir = nullptr;
+
+  for (int i = 1; i < objc; i++) {
+    std::string arg = Tcl_GetString(objv[i]);
+    if (arg == "-all")
+      upsize_all = true;
+    else if (arg == "-wns")
+      stop_on_wns_stall = true;
+    else if (!arg.empty() && arg[0] == '-')
+      invalid_args = true;
+    else if (!workdir)
+      workdir = Tcl_GetString(objv[i]);
+    else
+      invalid_args = true;
+  }
+
+  if (!workdir || invalid_args) {
+    Tcl_WrongNumArgs(interp, 1, objv, "?-all? ?-wns? workdir");
+    return TCL_ERROR;
+  }
+
+  Tcl_SetObjResult(
+      interp,
+      Tcl_NewIntObj(sizer->silisize(workdir, upsize_all, stop_on_wns_stall)));
+  return TCL_OK;
 }
 
 void dump_icg_json(const char *path) {
@@ -188,6 +218,11 @@ static int silisizerTclAppInit(Tcl_Interp *interp) {
 
   // Define swig commands.
   Silisizer_Init(interp);
+  Tcl_CreateObjCommand(interp,
+                       "sta::silisize",
+                       silisizeTclCmd,
+                       nullptr,
+                       nullptr);
   Sta_Init(interp);
 
   sta::Sta *sta = sta::Sta::sta();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,3 +13,21 @@ foreach(test_name ${ALL_TESTS})
       $<TARGET_FILE:silisizer-bin>
   )
 endforeach()
+
+add_test(
+  NAME silisize_flags
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND
+    $<TARGET_FILE:silisizer-bin>
+    -exit
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_silisize_flags.tcl
+)
+
+add_test(
+  NAME wns_policy
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/wns_policy
+  COMMAND
+    $<TARGET_FILE:silisizer-bin>
+    -exit
+    ${CMAKE_CURRENT_SOURCE_DIR}/wns_policy/test_wns_policy.tcl
+)

--- a/tests/picorv32/silisize.tcl
+++ b/tests/picorv32/silisize.tcl
@@ -2,4 +2,4 @@ read_liberty ../common/sky130_fd_sc_hd__tt_025C_1v80.lib.gz
 read_verilog picorv32.nl.v.gz
 link_design picorv32
 create_clock [get_ports clk] -name clk -period 8.004
-sta::silisize .
+sta::silisize -all .

--- a/tests/test_silisize_flags.tcl
+++ b/tests/test_silisize_flags.tcl
@@ -27,6 +27,8 @@ foreach command [list \
 
 if {![catch {sta::silisize -unknown $workdir} result]} {
     lappend failures "sta::silisize accepted an unknown flag"
+} elseif {$result ne {unknown option "-unknown": must be -all or -wns}} {
+    lappend failures "sta::silisize returned a misleading error: $result"
 }
 
 file delete -force $workdir

--- a/tests/test_silisize_flags.tcl
+++ b/tests/test_silisize_flags.tcl
@@ -1,0 +1,42 @@
+set failures {}
+set workdir [file normalize [file join [pwd] silisize_flags_tmp]]
+file mkdir [file join $workdir data]
+
+set netlist [file join $workdir empty.v]
+set stream [open $netlist w]
+puts $stream "module silisize_flags_top(); endmodule"
+close $stream
+set liberty [file normalize [file join \
+        [file dirname [info script]] \
+        ../third_party/OpenSTA/test/read_saif_null_instance.lib]]
+read_liberty $liberty
+read_verilog $netlist
+link_design silisize_flags_top
+
+foreach command [list \
+        [list sta::silisize $workdir] \
+        [list sta::silisize -all $workdir] \
+        [list sta::silisize -wns $workdir] \
+        [list sta::silisize -all -wns $workdir]] {
+    if {[catch $command result]} {
+        lappend failures "$command failed: $result"
+    } elseif {$result != 0} {
+        lappend failures "$command returned $result instead of 0"
+    }
+}
+
+if {![catch {sta::silisize -unknown $workdir} result]} {
+    lappend failures "sta::silisize accepted an unknown flag"
+}
+
+file delete -force $workdir
+
+if {[llength $failures]} {
+    puts "SILISIZE_FLAGS_TEST: FAIL"
+    foreach failure $failures {
+        puts "  - $failure"
+    }
+    exit 1
+}
+
+puts "SILISIZE_FLAGS_TEST: PASS"

--- a/tests/wns_policy/test_wns_policy.tcl
+++ b/tests/wns_policy/test_wns_policy.tcl
@@ -1,0 +1,32 @@
+set workdir [file normalize [file join [pwd] work]]
+file delete -force $workdir
+file mkdir [file join $workdir data]
+
+read_liberty wns_policy.lib
+read_verilog wns_policy.v
+link_design wns_policy
+
+create_clock -name test_clk -period 1.0
+set_input_delay 0.0 -clock test_clk [get_ports {a b}]
+set_output_delay 0.0 -clock test_clk [get_ports {fixed_y opt_y}]
+
+if {[sta::silisize -wns $workdir] != 0} {
+    puts "WNS_POLICY_TEST: FAIL (silisize returned an error)"
+    file delete -force $workdir
+    exit 1
+}
+
+set transforms [open [file join $workdir data resized_cells.tsv] r]
+set lines [split [string trim [read $transforms]] "\n"]
+close $transforms
+file delete -force $workdir
+
+# Adaptive batches resize 1, 2, then 4 cells. The third subsequent timing pass
+# still has the same unfixable WNS, so the policy stops before resizing the
+# final three eligible cells.
+if {[llength $lines] != 8} {
+    puts "WNS_POLICY_TEST: FAIL (expected 7 resizes, got [expr {[llength $lines] - 1}])"
+    exit 1
+}
+
+puts "WNS_POLICY_TEST: PASS"

--- a/tests/wns_policy/wns_policy.lib
+++ b/tests/wns_policy/wns_policy.lib
@@ -1,0 +1,85 @@
+library(wns_policy) {
+  delay_model : table_lookup;
+  time_unit : "1ns";
+  voltage_unit : "1V";
+  current_unit : "1mA";
+  capacitive_load_unit(1, pf);
+
+  cell(FIXED_X1) {
+    pin(A) {
+      direction : input;
+    }
+    pin(Y) {
+      direction : output;
+      function : "A";
+      timing() {
+        related_pin : "A";
+        timing_sense : positive_unate;
+        cell_rise(scalar) {
+          values("10.0");
+        }
+        cell_fall(scalar) {
+          values("10.0");
+        }
+        rise_transition(scalar) {
+          values("0.1");
+        }
+        fall_transition(scalar) {
+          values("0.1");
+        }
+      }
+    }
+  }
+
+  cell(BUF_sp0_X1) {
+    pin(A) {
+      direction : input;
+    }
+    pin(Y) {
+      direction : output;
+      function : "A";
+      timing() {
+        related_pin : "A";
+        timing_sense : positive_unate;
+        cell_rise(scalar) {
+          values("0.5");
+        }
+        cell_fall(scalar) {
+          values("0.5");
+        }
+        rise_transition(scalar) {
+          values("0.1");
+        }
+        fall_transition(scalar) {
+          values("0.1");
+        }
+      }
+    }
+  }
+
+  cell(BUF_sp1_X1) {
+    pin(A) {
+      direction : input;
+    }
+    pin(Y) {
+      direction : output;
+      function : "A";
+      timing() {
+        related_pin : "A";
+        timing_sense : positive_unate;
+        cell_rise(scalar) {
+          values("0.1");
+        }
+        cell_fall(scalar) {
+          values("0.1");
+        }
+        rise_transition(scalar) {
+          values("0.1");
+        }
+        fall_transition(scalar) {
+          values("0.1");
+        }
+      }
+    }
+  }
+}

--- a/tests/wns_policy/wns_policy.v
+++ b/tests/wns_policy/wns_policy.v
@@ -1,0 +1,29 @@
+module wns_policy(
+    input a,
+    input b,
+    output fixed_y,
+    output opt_y
+);
+  wire n0;
+  wire n1;
+  wire n2;
+  wire n3;
+  wire n4;
+  wire n5;
+  wire n6;
+  wire n7;
+  wire n8;
+
+  FIXED_X1 fixed_path(.A(a), .Y(fixed_y));
+
+  BUF_sp0_X1 opt_path_0(.A(b), .Y(n0));
+  BUF_sp0_X1 opt_path_1(.A(n0), .Y(n1));
+  BUF_sp0_X1 opt_path_2(.A(n1), .Y(n2));
+  BUF_sp0_X1 opt_path_3(.A(n2), .Y(n3));
+  BUF_sp0_X1 opt_path_4(.A(n3), .Y(n4));
+  BUF_sp0_X1 opt_path_5(.A(n4), .Y(n5));
+  BUF_sp0_X1 opt_path_6(.A(n5), .Y(n6));
+  BUF_sp0_X1 opt_path_7(.A(n6), .Y(n7));
+  BUF_sp0_X1 opt_path_8(.A(n7), .Y(n8));
+  BUF_sp0_X1 opt_path_9(.A(n8), .Y(opt_y));
+endmodule


### PR DESCRIPTION
## Summary
- add an `-all` policy to upsize every eligible offender in each timing pass
- add a combinable `-wns` policy that stops after three rounds without WNS improvement
- document the Tcl interface and add flag parsing and WNS-stall regression coverage

## Test plan
- [x] `cmake --build build -j 8`
- [x] `ctest --test-dir build --output-on-failure` (4 tests)

Made with [Cursor](https://cursor.com)