### PR TITLE
Always create data/resized_cells.tsv; add sizing-policy tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build
 dbuild
+
+# silisize test output (data/resized_cells.tsv) written into test working dirs
+tests/**/data/

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ The policies can be combined:
 ```tcl
 sta::silisize -all -wns workdir
 ```
+
+`silisize` always creates `workdir/data/resized_cells.tsv` (header only when no
+cells are resized) so Preqorsor can back-annotate SPEED==2 runs. Failure to
+create that file is a hard error.

--- a/src/Silisizer.cpp
+++ b/src/Silisizer.cpp
@@ -88,6 +88,18 @@ int Silisizer::silisize(const char *workdir,
   }
   transforms << "Scope" << "\t" << "Instance" << std::endl;
 
+  // Flush/close the transforms file and surface any write failure (disk full,
+  // NFS stale handle, flush error) as a hard error, so Preqorsor never
+  // back-annotates a truncated resized_cells.tsv.
+  auto close_transforms = [&transforms, &transforms_path]() -> int {
+    transforms.close();
+    if (transforms.fail()) {
+      std::cerr << "silisize: failed writing " << transforms_path << std::endl;
+      return 1;
+    }
+    return 0;
+  };
+
   // Iterate until the maximum number of iterations is reached
   double previous_wns = 1;
   int wns_stall_rounds = 0;
@@ -277,8 +289,7 @@ int Silisizer::silisize(const char *workdir,
                   << "This should never happen!" << std::endl
                   << "Final WNS: " << -(wns * 1e12) << std::endl
                   << "Timing optimization partially done!" << std::endl;
-        transforms.close();
-        return 0;
+        return close_transforms();
       }
       // Swap the cell with speed 1 cell
       Sta::sta()->replaceCell(offender, to_cell);
@@ -324,8 +335,7 @@ int Silisizer::silisize(const char *workdir,
   }
   
   // Clean up
-  transforms.close();
-  return 0;
+  return close_transforms();
 }
 
 // Remove escape characters from JSON output

--- a/src/Silisizer.cpp
+++ b/src/Silisizer.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <list>
@@ -67,11 +68,25 @@ int Silisizer::silisize(const char *workdir,
   // Effort variables (multiply swaps per iteration by 2 until complete)
   int swaps_per_iter = 1;
 
-  // Output the header for back-annotation CSV
+  // Output the header for back-annotation TSV. Preqorsor always reads this
+  // file after SPEED==2 STA, so failing to create it must be a hard error.
   std::string workdir_str = workdir;
-  std::ofstream transforms(workdir_str + "/data/resized_cells.tsv");
-  if (transforms.good())
-    transforms << "Scope" << "\t" << "Instance" << std::endl;
+  std::string data_dir = workdir_str + "/data";
+  std::string transforms_path = data_dir + "/resized_cells.tsv";
+  std::error_code ec;
+  std::filesystem::create_directories(data_dir, ec);
+  if (ec) {
+    std::cerr << "silisize: cannot create " << data_dir << ": " << ec.message()
+              << std::endl;
+    return 1;
+  }
+  std::ofstream transforms(transforms_path);
+  if (!transforms.good()) {
+    std::cerr << "silisize: cannot open " << transforms_path << " for write"
+              << std::endl;
+    return 1;
+  }
+  transforms << "Scope" << "\t" << "Instance" << std::endl;
 
   // Iterate until the maximum number of iterations is reached
   double previous_wns = 1;
@@ -269,8 +284,7 @@ int Silisizer::silisize(const char *workdir,
       Sta::sta()->replaceCell(offender, to_cell);
       // Record the transformation for back-annotation in the folded model
       // (unique module name/cell name)
-      if (transforms.good())
-        transforms << parentcellname << "\t" << cellname << std::endl;
+      transforms << parentcellname << "\t" << cellname << std::endl;
     }
 
     // Get delta WNS and delta WNS fraction

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,9 +132,14 @@ static int silisizeTclCmd(ClientData,
     return TCL_ERROR;
   }
 
-  Tcl_SetObjResult(
-      interp,
-      Tcl_NewIntObj(sizer->silisize(workdir, upsize_all, stop_on_wns_stall)));
+  int status = sizer->silisize(workdir, upsize_all, stop_on_wns_stall);
+  Tcl_SetObjResult(interp, Tcl_NewIntObj(status));
+  if (status != 0) {
+    std::string message =
+        "silisize failed with status " + std::to_string(status);
+    Tcl_SetObjResult(interp, Tcl_NewStringObj(message.c_str(), -1));
+    return TCL_ERROR;
+  }
   return TCL_OK;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,13 +133,13 @@ static int silisizeTclCmd(ClientData,
   }
 
   int status = sizer->silisize(workdir, upsize_all, stop_on_wns_stall);
-  Tcl_SetObjResult(interp, Tcl_NewIntObj(status));
   if (status != 0) {
     std::string message =
         "silisize failed with status " + std::to_string(status);
     Tcl_SetObjResult(interp, Tcl_NewStringObj(message.c_str(), -1));
     return TCL_ERROR;
   }
+  Tcl_SetObjResult(interp, Tcl_NewIntObj(status));
   return TCL_OK;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,10 +24,28 @@ add_test(
 )
 
 add_test(
+  NAME resized_cells_tsv
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND
+    $<TARGET_FILE:silisizer-bin>
+    -exit
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_resized_cells_tsv.tcl
+)
+
+add_test(
   NAME wns_policy
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/wns_policy
   COMMAND
     $<TARGET_FILE:silisizer-bin>
     -exit
     ${CMAKE_CURRENT_SOURCE_DIR}/wns_policy/test_wns_policy.tcl
+)
+
+add_test(
+  NAME all_policy
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/wns_policy
+  COMMAND
+    $<TARGET_FILE:silisizer-bin>
+    -exit
+    ${CMAKE_CURRENT_SOURCE_DIR}/wns_policy/test_all_policy.tcl
 )

--- a/tests/test_resized_cells_tsv.tcl
+++ b/tests/test_resized_cells_tsv.tcl
@@ -1,0 +1,46 @@
+# silisize must always create data/resized_cells.tsv (even when data/ is missing)
+set workdir [file normalize [file join [pwd] resized_cells_tsv_tmp]]
+file delete -force $workdir
+file mkdir $workdir
+# deliberately omit data/ — silisize must create it
+
+set netlist [file join $workdir empty.v]
+set stream [open $netlist w]
+puts $stream "module resized_cells_top(); endmodule"
+close $stream
+set liberty [file normalize [file join \
+        [file dirname [info script]] \
+        ../third_party/OpenSTA/test/read_saif_null_instance.lib]]
+read_liberty $liberty
+read_verilog $netlist
+link_design resized_cells_top
+
+if {[catch {sta::silisize $workdir} result]} {
+    puts "RESIZED_CELLS_TSV_TEST: FAIL (silisize error: $result)"
+    file delete -force $workdir
+    exit 1
+}
+if {$result != 0} {
+    puts "RESIZED_CELLS_TSV_TEST: FAIL (silisize returned $result)"
+    file delete -force $workdir
+    exit 1
+}
+
+set tsv [file join $workdir data resized_cells.tsv]
+if {![file exists $tsv]} {
+    puts "RESIZED_CELLS_TSV_TEST: FAIL (missing $tsv)"
+    file delete -force $workdir
+    exit 1
+}
+
+set transforms [open $tsv r]
+set lines [split [string trim [read $transforms]] "\n"]
+close $transforms
+file delete -force $workdir
+
+if {[llength $lines] < 1 || [lindex $lines 0] ne "Scope\tInstance"} {
+    puts "RESIZED_CELLS_TSV_TEST: FAIL (bad header: [lindex $lines 0])"
+    exit 1
+}
+
+puts "RESIZED_CELLS_TSV_TEST: PASS"

--- a/tests/wns_policy/test_all_policy.tcl
+++ b/tests/wns_policy/test_all_policy.tcl
@@ -1,0 +1,37 @@
+# -all (sizing_fast) must upsize every eligible offender in one timing pass
+set workdir [file normalize [file join [pwd] work_all]]
+file delete -force $workdir
+file mkdir [file join $workdir data]
+
+read_liberty wns_policy.lib
+read_verilog wns_policy.v
+link_design wns_policy
+
+create_clock -name test_clk -period 1.0
+set_input_delay 0.0 -clock test_clk [get_ports {a b}]
+set_output_delay 0.0 -clock test_clk [get_ports {fixed_y opt_y}]
+
+if {[catch {sta::silisize -all $workdir} result]} {
+    puts "ALL_POLICY_TEST: FAIL (silisize error: $result)"
+    file delete -force $workdir
+    exit 1
+}
+if {$result != 0} {
+    puts "ALL_POLICY_TEST: FAIL (silisize returned $result)"
+    file delete -force $workdir
+    exit 1
+}
+
+set transforms [open [file join $workdir data resized_cells.tsv] r]
+set lines [split [string trim [read $transforms]] "\n"]
+close $transforms
+file delete -force $workdir
+
+# Ten BUF_sp0 cells sit on the optimizable path; -all resizes all of them
+# in the first pass (adaptive mode would only resize 1, then 2, then 4).
+if {[llength $lines] != 11} {
+    puts "ALL_POLICY_TEST: FAIL (expected 10 resizes, got [expr {[llength $lines] - 1}])"
+    exit 1
+}
+
+puts "ALL_POLICY_TEST: PASS"


### PR DESCRIPTION
## Summary
- A customer's Preqorsor speed-2 run crashed at back-annotation with `FileNotFoundError: '.../data/resized_cells.tsv'`. Root cause: `silisize()` opened the TSV only if the parent `data/` directory already existed and silently skipped writing otherwise (e.g. dir missing/not yet visible on NFS), leaving no file for Preqorsor to read.
- `silisize()` now creates `data/` itself (`std::filesystem::create_directories`), **always** writes `resized_cells.tsv` (header-only when nothing is resized), and treats a genuine I/O failure as a hard error (returns non-zero; the `sta::silisize` Tcl command surfaces it as a `TCL_ERROR`).
- This also fixes an old consistency bug: previously `replaceCell()` ran but the transform record was dropped when the stream wasn't writable, so STA's netlist could be sized while Preqorsor saw no resizes.
- Adds tests: `resized_cells_tsv` (file is created even when `data/` is absent) and `wns_policy/all_policy` for the `-all` (`sizing_fast`) policy, alongside the existing `-wns` (`sizing_wns`) test; both registered in `tests/CMakeLists.txt`.

Companion Preqorsor PR (defense-in-depth: fail loudly instead of crashing if the file is still absent): Silimate/preqorsor#2118

> Note: this branch also carries the pre-existing local `Bump OpenSTA` submodule-pointer commit (not yet on `main`), which reflects the OpenSTA revision these changes were built and tested against.

## Test plan
- [x] `ctest -R "resized_cells_tsv|wns_policy|all_policy|silisize_flags"` → 4/4 pass
- [x] `resized_cells_tsv` deliberately omits `data/` and confirms the file (with header) is created
- [x] `wns_policy` (`-wns`) and `all_policy` (`-all`) confirm the two sizing policies resize as expected