### PR TITLE
[CUS-653] latch may cause hang or extended runtime

### DIFF
--- a/src/Silisizer.cpp
+++ b/src/Silisizer.cpp
@@ -28,6 +28,7 @@
 #include "sta/PathEnd.hh"
 #include "sta/PortDirection.hh"
 #include "sta/Sta.hh"
+#include "sta/TimingRole.hh"
 
 namespace silisizer {
 
@@ -164,6 +165,8 @@ int Silisizer::silisize(const char *workdir,
         sta::Pin *pin = p->pin(this);
         // Get previous arc
         sta::TimingArc* prev_arc = p->prevArc(this);
+        // Past a transparent latch the path is in a different launch cycle
+        if (prev_arc && prev_arc->role()->isLatchDtoQ()) break;
         // Get the arc delay
         sta::Delay delay = 0.0f;
         if (prev_arc) delay = prev_arc->intrinsicDelay();


### PR DESCRIPTION
Fix silisize hang on designs with transparent latches
Symptom
silisize hangs indefinitely. The last line logged is Make path ends; the Resizing instance line that should follow within seconds never appears. While hung the process pins a single core with a flat memory footprint. Only affects speed 2, since speed 1 never calls silisize.

Cause
Silisizer::silisize walks each violating path backwards to score offending instances:

for (sta::Path* p = path; p && !p->isNull(); p = p->prevPath()) {
The only exit is a null pointer. Each Path has exactly one prev_path_, so following it is a functional graph — you either reach null or revisit a node and loop forever. Normally you always reach null, because each step moves strictly down the logic levels. Transparent latches break that: a path can pass through a latch D→Q arc and back around to itself, closing the chain into a cycle.

OpenSTA guards against this in its own equivalent walk, PathExpanded::expand, with the comment "This breaks latch loop paths." Ours had no equivalent.

Nothing upstream catches it for us. Levelize::searchThru skips latch D→Q arcs, so a latch loop is never treated as a graph cycle and no back edge inside one is marked isDisabledLoop. And sta_latch_checks_enabled is unrelated — it only gates whether a latch endpoint is reported, not latch transparency or the shape of the prev_path chain.

Fix
// Past a transparent latch the path is in a different launch cycle
if (prev_arc && prev_arc->role()->isLatchDtoQ()) break;
Keyed off the arc's role, which is structural, so it can't be defeated by config or by the latch enable state.

This also improves scoring. Past a transparent latch the path is in a previous clock cycle, so those gates belong to a different launch event and shouldn't be charged against this endpoint's slack.