### PR TITLE
[ENG-2522] Cell swaps miss due to escape identifiers

### DIFF
--- a/src/Silisizer.cpp
+++ b/src/Silisizer.cpp
@@ -357,7 +357,8 @@ int Silisizer::silisize(const char *workdir,
 
       // Record the transformation for back-annotation in the folded model
       // (unique module name/cell name)
-      transforms << parentcellname << "\t" << cellname << std::endl;
+      transforms << reverseOpenSTANaming(parentcellname) << "\t" << cellname
+                 << std::endl;
     }
 
     // Get delta WNS and delta WNS fraction


### PR DESCRIPTION
Silisize wrote OpenSTA-escaped Scope names (`mod\[1\]`) into `resized_cells.tsv`, which caused mismatch

Fix: unescape Scope when writing the TSV.

STA `replaceCell` is unchanged.
